### PR TITLE
Issue 38

### DIFF
--- a/src/Pages/Auth/SignIn.jsx
+++ b/src/Pages/Auth/SignIn.jsx
@@ -52,7 +52,8 @@ class SignInPage extends Component {
     const tisRemembered = this.state.isRemembered;
     ipcRenderer.send("log-in", {
       password: tpas,
-      user: username,
+      username: username,
+      email: username,
       isRemembered: tisRemembered
     });
     console.log("click");

--- a/src/Pages/Auth/SignIn.jsx
+++ b/src/Pages/Auth/SignIn.jsx
@@ -29,7 +29,7 @@ class SignInPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      email: "",
+      username: "",
       password: "",
       error: null,
       openDialog: false,
@@ -48,11 +48,11 @@ class SignInPage extends Component {
 
   login = () => {
     const tpas = this.state.password;
-    const temail = this.state.email;
+    const username = this.state.username;
     const tisRemembered = this.state.isRemembered;
     ipcRenderer.send("log-in", {
       password: tpas,
-      email: temail,
+      user: username,
       isRemembered: tisRemembered
     });
     console.log("click");
@@ -94,13 +94,13 @@ class SignInPage extends Component {
                     <TextField
                       className={classes.field}
                       autoFocus
-                      autoComplete="email"
-                      type="email"
-                      name="email"
-                      id="email"
-                      label="Email"
+                      autoComplete="username"
+                      type="username"
+                      name="username"
+                      id="username"
+                      label="Username"
                       onChange={this.handleChange}
-                      value={this.state.email}
+                      value={this.state.username}
                       InputProps={{
                         className: classes.input
                       }}


### PR DESCRIPTION
Changes have been implemented.

1) Email text field now displays the text "Username"

2) ipcRenderer sends now two keys: 'username' and 'email', both evaluated to 'username'
   I suggest we either change the functionality only to be for username, or adjust the text field to "Username or email" 

This changes won't work right now, as the ipcMain reads "msg.user", which should be "msg.username"